### PR TITLE
fix: added name attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       <p>{{ message }}</p>
       <button v-on:click="reverseMessage">Reverse Message</button>
       <form method="post">
-        <p><label>Credit card number: </label><input type="text" id="ccnumber" inputmode="numeric" autocomplete="cc-number">
+        <p><label>Credit card number: </label><input type="text" id="ccnumber" name="ccnumber" inputmode="numeric" autocomplete="cc-number">
         <p><input type=submit value="Continue...">
       </form>
     </div>


### PR DESCRIPTION
iOS Safari では id, name の両方がないと autocomplete が働かない疑いがあるため。
this will closes #5 